### PR TITLE
remove binding.pry to prevent error

### DIFF
--- a/app/controllers/admins/admins_controller.rb
+++ b/app/controllers/admins/admins_controller.rb
@@ -79,9 +79,7 @@ class Admins::AdminsController < ApplicationController
 	def restore
 		@user = User.with_deleted.find(params[:user_id])
 		email = @user.email
-		binding.pry
 		if @user.restore(:recursive => true)
-		binding.pry
 			email.slice!(/\d\d\d\d[-]\d\d[-]\d\d[t]\d\d[:]\d\d[:]\d\d[+]\d\d[:]\d\d/)
 			@user.update(email: email)
 			flash[:notice] = "ユーザーを再入会させました"

--- a/app/controllers/users/chatmessages_controller.rb
+++ b/app/controllers/users/chatmessages_controller.rb
@@ -3,7 +3,6 @@ class Users::ChatmessagesController < ApplicationController
 	def create
 		chatroom = Chatroom.find(params[:chatmessage][:chatroom_id])
 		@message = Chatmessage.new(message_params)
-		binding.pry
 		if @message.save
 			redirect_to users_chatroom_path(id: chatroom.id, other_user_id: params[:other_user_id])
 		else


### PR DESCRIPTION
production環境下でエラーを出してしまったbinding.pry(＃つけ忘れ)を消去しました。